### PR TITLE
fix: reset user scrolling after the apply state changed

### DIFF
--- a/src/components/ai-writer/use-ensure-bottom-visible.ts
+++ b/src/components/ai-writer/use-ensure-bottom-visible.ts
@@ -21,14 +21,19 @@ function useEnsureBottomVisible() {
     applyingState,
   } = useWriterContext();
 
+  const enableAutoScroll = useCallback(() => {
+    isUserScrollingRef.current = false;
+    setIsAutoScrollEnabled(true);
+  }, []);
+
   const applyingStateRef = useRef(applyingState);
 
   useEffect(() => {
     applyingStateRef.current = applyingState;
     if(applyingState === ApplyingState.idle) {
-      setIsAutoScrollEnabled(true);
+      enableAutoScroll();
     }
-  }, [applyingState]);
+  }, [applyingState, enableAutoScroll]);
 
   const getTarget = useCallback(() => {
     return document.querySelector('.writer-anchor');
@@ -75,11 +80,6 @@ function useEnsureBottomVisible() {
     }
 
   }, [getTarget, isAutoScrollEnabled]);
-
-  const enableAutoScroll = useCallback(() => {
-    isUserScrollingRef.current = false;
-    setIsAutoScrollEnabled(true);
-  }, []);
 
   useEffect(() => {
     if(!isAutoScrollEnabled) return;


### PR DESCRIPTION
<!---
Thank you for submitting a pull request to the AppFlowy Web! The team will dedicate their best efforts to reviewing and approving your PR. If you have any questions or feedback, feel free to join our [Discord](https://discord.gg/wdjWUXXhtw).
-->


### **Description**
<!---
Provide a clear and concise description of the changes introduced in this pull request for AppFlowy Web. What problem does it solve? What value does it add?
-->

---

### **Checklist**
<!---
Before marking your pull request as ready for review, ensure the following checklist is complete.
-->

#### **General**
- [ ] I've included relevant documentation or comments for the changes introduced.
- [ ] I've tested the changes in multiple environments (e.g., different browsers, operating systems).

#### **Testing**
- [ ] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [ ] For feature additions, I've added a preview (video, screenshot, or demo) in the "Feature Preview" section.
- [ ] I've verified that this feature integrates seamlessly with existing functionality.

## Summary by Sourcery

Improve auto-scrolling behavior in the AI writer component by resetting user scrolling state when the applying state changes to idle

Bug Fixes:
- Fixed an issue with auto-scrolling not being re-enabled correctly when the AI writing process reaches an idle state

Enhancements:
- Refactored the auto-scrolling logic to more explicitly handle state transitions
- Moved the auto-scroll enabling logic into a separate callback for better code organization