### PR TITLE
fix: padding between messages in ai message list

### DIFF
--- a/src/chat/main.tsx
+++ b/src/chat/main.tsx
@@ -34,7 +34,7 @@ function Main(props: ChatProps) {
                       <ChatMessages currentUser={currentUser} />
                       <motion.div
                         layout
-                        className={cn('w-full relative flex py-6 justify-center max-sm:hidden')}
+                        className={cn('w-full relative flex pb-6 justify-center max-sm:hidden')}
                       >
                         <AnimatePresence mode="wait">
                           {!selectionMode && <ChatInput />}

--- a/src/components/chat-messages/ai-answer.tsx
+++ b/src/components/chat-messages/ai-answer.tsx
@@ -21,7 +21,7 @@ export function AIAnswer({
   const isLast = messageIds.indexOf(id) === 0;
   
   return (
-    <div className={`chat-message flex flex-col w-full ${isLast ? 'mb-9' : 'mb-0.5'}`}>
+    <div className={`chat-message flex flex-col w-full pl-0.5 ${isLast ? 'mb-9' : 'mb-0.5'}`}>
       <div className={'flex gap-2 w-full overflow-hidden py-1'}>
         <MessageCheckbox id={id} />
         <EditorProvider>

--- a/src/components/chat-messages/ai-answer.tsx
+++ b/src/components/chat-messages/ai-answer.tsx
@@ -1,7 +1,6 @@
 import { AnswerMd } from '@/components/chat-messages/answer-md';
 import { MessageActions } from '@/components/chat-messages/message-actions';
 import MessageSources from '@/components/chat-messages/message-sources';
-import { useChatMessagesContext } from '@/provider/messages-provider';
 import { ChatMessageMetadata } from '@/types';
 import { EditorProvider } from '@appflowyinc/editor';
 import MessageCheckbox from './message-checkbox';
@@ -17,11 +16,8 @@ export function AIAnswer({
   sources?: ChatMessageMetadata[];
   isHovered: boolean;
 }) {
-  const { messageIds } = useChatMessagesContext();
-  const isLast = messageIds.indexOf(id) === 0;
-  
   return (
-    <div className={`chat-message flex flex-col w-full pl-0.5 ${isLast ? 'mb-9' : 'mb-0.5'}`}>
+    <div className={`chat-message flex flex-col w-full pl-0.5 relative`}>
       <div className={'flex gap-2 w-full overflow-hidden py-1'}>
         <MessageCheckbox id={id} />
         <EditorProvider>

--- a/src/components/chat-messages/ai-answer.tsx
+++ b/src/components/chat-messages/ai-answer.tsx
@@ -1,6 +1,7 @@
 import { AnswerMd } from '@/components/chat-messages/answer-md';
 import { MessageActions } from '@/components/chat-messages/message-actions';
 import MessageSources from '@/components/chat-messages/message-sources';
+import { useChatMessagesContext } from '@/provider/messages-provider';
 import { ChatMessageMetadata } from '@/types';
 import { EditorProvider } from '@appflowyinc/editor';
 import MessageCheckbox from './message-checkbox';
@@ -16,9 +17,12 @@ export function AIAnswer({
   sources?: ChatMessageMetadata[];
   isHovered: boolean;
 }) {
+  const { messageIds } = useChatMessagesContext();
+  const isLast = messageIds.indexOf(id) === 0;
+  
   return (
-    <div className={'chat-message flex flex-col w-full gap-1'}>
-      <div className={'flex gap-2 w-full overflow-hidden'}>
+    <div className={`chat-message flex flex-col w-full ${isLast ? 'mb-9' : 'mb-0.5'}`}>
+      <div className={'flex gap-2 w-full overflow-hidden py-1'}>
         <MessageCheckbox id={id} />
         <EditorProvider>
           <AnswerMd id={id} mdContent={content} />

--- a/src/components/chat-messages/assistant-message.tsx
+++ b/src/components/chat-messages/assistant-message.tsx
@@ -79,7 +79,7 @@ export function AssistantMessage({ id, isHovered }: { id: number; isHovered: boo
       className={cn(
         'assistant-message overflow-hidden transform transition-transform flex flex-col w-full gap-1',
         error || loading ? 'mb-9' : '',
-        !done || isLast ? 'mb-9' : 'mb-5',
+        !done || isLast ? 'mb-9' : 'mb-0.5',
       )}
     >
       {error ? (

--- a/src/components/chat-messages/assistant-message.tsx
+++ b/src/components/chat-messages/assistant-message.tsx
@@ -14,11 +14,10 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { EditorProvider } from '@appflowyinc/editor';
 import Error from '@/assets/icons/error.svg?react';
 import MessageCheckbox from './message-checkbox';
-import { cn } from '@/lib/utils';
 
 export function AssistantMessage({ id, isHovered }: { id: number; isHovered: boolean }) {
   const isInitialLoad = useRef(true);
-  const { getMessage, messageIds } = useChatMessagesContext();
+  const { getMessage } = useChatMessagesContext();
   const { responseFormat, responseMode } = useResponseFormatContext();
   const { fetchAnswerStream } = useMessagesHandlerContext();
 
@@ -26,7 +25,6 @@ export function AssistantMessage({ id, isHovered }: { id: number; isHovered: boo
 
   const message = getMessage(id);
 
-  const isLast = messageIds.indexOf(id) === 0;
   const questionId = id - 1;
   const sources = message?.meta_data;
 
@@ -76,11 +74,9 @@ export function AssistantMessage({ id, isHovered }: { id: number; isHovered: boo
 
   return (
     <div
-      className={cn(
-        'assistant-message transform transition-transform flex flex-col w-full gap-1',
-        error || loading ? 'mb-9' : '',
-        !done || isLast ? 'mb-9' : 'mb-0.5',
-      )}
+      className={
+        'assistant-message transform transition-transform flex flex-col w-full gap-1 relative'
+      }
     >
       {error ? (
         <div className={`flex items-center w-full justify-center`}>

--- a/src/components/chat-messages/assistant-message.tsx
+++ b/src/components/chat-messages/assistant-message.tsx
@@ -77,7 +77,7 @@ export function AssistantMessage({ id, isHovered }: { id: number; isHovered: boo
   return (
     <div
       className={cn(
-        'assistant-message overflow-hidden transform transition-transform flex flex-col w-full gap-1',
+        'assistant-message transform transition-transform flex flex-col w-full gap-1',
         error || loading ? 'mb-9' : '',
         !done || isLast ? 'mb-9' : 'mb-0.5',
       )}

--- a/src/components/chat-messages/assistant-message.tsx
+++ b/src/components/chat-messages/assistant-message.tsx
@@ -13,17 +13,20 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { EditorProvider } from '@appflowyinc/editor';
 import Error from '@/assets/icons/error.svg?react';
+import MessageCheckbox from './message-checkbox';
+import { cn } from '@/lib/utils';
 
 export function AssistantMessage({ id, isHovered }: { id: number; isHovered: boolean }) {
   const isInitialLoad = useRef(true);
-  const { getMessage } = useChatMessagesContext();
+  const { getMessage, messageIds } = useChatMessagesContext();
   const { responseFormat, responseMode } = useResponseFormatContext();
   const { fetchAnswerStream } = useMessagesHandlerContext();
 
   const { getMessageSuggestions } = useSuggestionsContext();
 
   const message = getMessage(id);
-  const ref = useRef<HTMLDivElement>(null);
+
+  const isLast = messageIds.indexOf(id) === 0;
   const questionId = id - 1;
   const sources = message?.meta_data;
 
@@ -72,7 +75,13 @@ export function AssistantMessage({ id, isHovered }: { id: number; isHovered: boo
   }, [questionId, getMessageSuggestions]);
 
   return (
-    <div className={'assistant-message overflow-hidden transform transition-transform flex flex-col w-full gap-1'}>
+    <div
+      className={cn(
+        'assistant-message overflow-hidden transform transition-transform flex flex-col w-full gap-1',
+        error || loading ? 'mb-9' : '',
+        !done || isLast ? 'mb-9' : 'mb-5',
+      )}
+    >
       {error ? (
         <div className={`flex items-center w-full justify-center`}>
           <div className="max-w-[480px]">
@@ -88,25 +97,25 @@ export function AssistantMessage({ id, isHovered }: { id: number; isHovered: boo
             </Alert>
           </div>
         </div>
-      ) : (
-        <div ref={ref} className={`flex gap-2 w-full  overflow-hidden`}>
-          <div className={`flex gap-2 ${loading ? 'items-center' : ''}`}>
-            {loading && <span className={'text-foreground opacity-60 text-xs'}>{t('generating')}</span>}
-            {loading && <LoadingDots />}
+      ) : loading
+        ? (
+          <div className={`flex gap-2 overflow-hidden items-center`}>
+            <span className={'text-foreground opacity-60 text-sm'}>{t('generating')}</span>
+            <LoadingDots />
           </div>
-
-          <div className={'flex-1 w-full overflow-hidden'}>
-            {content && (
-              <EditorProvider>
-                <AnswerMd id={id} mdContent={content} />
-              </EditorProvider>
-            )}
+        ) :
+        content && (
+          <div className={'flex gap-2 w-full overflow-hidden py-1'}>
+            <MessageCheckbox id={id} />
+            <EditorProvider>
+              <AnswerMd id={id} mdContent={content} />
+            </EditorProvider>
           </div>
-        </div>
-      )}
+        )
+      }
       {sources && sources.length > 0 ? <MessageSources sources={sources} /> : null}
       {done && <MessageActions id={id} isHovered={isHovered} />}
-      {suggestions && <MessageSuggestions suggestions={suggestions} />}
+      {suggestions && suggestions.items.length > 0 ? <MessageSuggestions suggestions={suggestions} /> : null}
     </div>
   );
 }

--- a/src/components/chat-messages/assistant-message.tsx
+++ b/src/components/chat-messages/assistant-message.tsx
@@ -99,13 +99,13 @@ export function AssistantMessage({ id, isHovered }: { id: number; isHovered: boo
         </div>
       ) : loading
         ? (
-          <div className={`flex gap-2 overflow-hidden items-center`}>
+          <div className={`flex gap-2 overflow-hidden items-center pl-0.5`}>
             <span className={'text-foreground opacity-60 text-sm'}>{t('generating')}</span>
             <LoadingDots />
           </div>
         ) :
         content && (
-          <div className={'flex gap-2 w-full overflow-hidden py-1'}>
+          <div className={'flex gap-2 w-full overflow-hidden py-1 pl-0.5'}>
             <MessageCheckbox id={id} />
             <EditorProvider>
               <AnswerMd id={id} mdContent={content} />

--- a/src/components/chat-messages/index.tsx
+++ b/src/components/chat-messages/index.tsx
@@ -126,6 +126,7 @@ export function ChatMessages({ currentUser }: {
             <div
               onMouseMove={() => setHoveredId(id)}
               key={id}
+              className={'overflow-x-hidden'}
             >
               <Message
                 id={id}

--- a/src/components/chat-messages/index.tsx
+++ b/src/components/chat-messages/index.tsx
@@ -11,6 +11,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import InfiniteScroll from 'react-infinite-scroll-component';
 import { ArrowDown } from 'lucide-react';
 import { motion } from 'framer-motion';
+import { cn } from '@/lib/utils';
 
 const LoadingIndicator = () => (
   <div className="flex items-center justify-center w-full h-[48px]">
@@ -104,8 +105,11 @@ export function ChatMessages({ currentUser }: {
         transition={ANIMATION_PRESETS.SPRING_GENTLE}
         id="messages-scroller"
         ref={scrollContainerRef}
-        style={{ flexDirection: 'column-reverse', paddingBottom: selectionMode ? '72px' : '0px' }}
-        className="flex px-1 relative py-8 appflowy-scrollbar overflow-x-hidden gap-4 h-full w-full overflow-auto"
+        style={{ flexDirection: 'column-reverse' }}
+        className={cn(
+          "flex px-1 relative pt-8 appflowy-scrollbar overflow-x-hidden gap-4 h-full w-full overflow-auto",
+          selectionMode ? 'pb-9' : 'pb-2',
+        )}
       >
         <InfiniteScroll
           dataLength={messageIds.length}
@@ -141,7 +145,10 @@ export function ChatMessages({ currentUser }: {
 
       </motion.div>
       {showScrollButton && (
-        <div className={'absolute left-1/2 bottom-2 transform -translate-x-1/2'}>
+        <div className={cn(
+          'absolute left-1/2 transform -translate-x-1/2',
+          selectionMode ? 'bottom-12' : 'bottom-6',
+        )}>
           <Button
             variant={'outline'}
             size={'icon'}

--- a/src/components/chat-messages/index.tsx
+++ b/src/components/chat-messages/index.tsx
@@ -98,7 +98,7 @@ export function ChatMessages({ currentUser }: {
 
   return (
     <div
-      className="relative w-full flex-1 overflow-hidden"
+      className="relative w-full flex-1 overflow-x-hidden"
     >
       <motion.div
         layout
@@ -126,7 +126,6 @@ export function ChatMessages({ currentUser }: {
             <div
               onMouseMove={() => setHoveredId(id)}
               key={id}
-              className={'overflow-x-hidden'}
             >
               <Message
                 id={id}

--- a/src/components/chat-messages/index.tsx
+++ b/src/components/chat-messages/index.tsx
@@ -98,7 +98,7 @@ export function ChatMessages({ currentUser }: {
 
   return (
     <div
-      className="relative w-full flex-1 overflow-x-hidden"
+      className="relative w-full flex-1 overflow-hidden"
     >
       <motion.div
         layout

--- a/src/components/chat-messages/message-actions.tsx
+++ b/src/components/chat-messages/message-actions.tsx
@@ -102,10 +102,10 @@ export function MessageActions({
     <div
       ref={ref}
       className={cn(
-        "flex max-sm:hidden gap-2 min-w-none w-fit mt-2",
+        "flex max-sm:hidden gap-2 min-w-0 w-fit mt-2",
         isLast
           ? `min-h-[28px]`
-          : `min-h-[34px] ${isHovered ? 'p-0.5 border border-border rounded-[8px]' : ''}`
+          : `min-h-[34px] ml-0.5 ${isHovered ? 'p-0.5 border border-border rounded-[8px]' : ''}`
       )}
     >
       {visible && message && (

--- a/src/components/chat-messages/message-actions.tsx
+++ b/src/components/chat-messages/message-actions.tsx
@@ -102,10 +102,10 @@ export function MessageActions({
     <div
       ref={ref}
       className={cn(
-        "flex max-sm:hidden gap-2 min-w-0 w-fit mt-2",
+        "flex max-sm:hidden gap-2 min-w-0 w-fit",
         isLast
-          ? `min-h-[28px]`
-          : `min-h-[34px] ml-0.5 absolute -bottom-[34px] ${isHovered ? 'p-0.5 border border-border rounded-[8px] shadow-md' : ''}`
+          ? `min-h-[28px] mt-2`
+          : `min-h-[34px] ml-0.5 absolute -bottom-[34px] ${isHovered ? 'p-0.5 border border-border rounded-[8px] shadow-popover' : ''}`
       )}
     >
       {visible && message && (

--- a/src/components/chat-messages/message-actions.tsx
+++ b/src/components/chat-messages/message-actions.tsx
@@ -8,7 +8,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { useToast } from '@/hooks/use-toast';
 import { useTranslation } from '@/i18n';
 import { convertToAppFlowyFragment } from '@/lib/copy';
-import { convertToPageData } from '@/lib/utils';
+import { cn, convertToPageData } from '@/lib/utils';
 import { useEditorContext } from '@/provider/editor-provider';
 import { useChatMessagesContext } from '@/provider/messages-provider';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -101,8 +101,12 @@ export function MessageActions({
   return (
     <div
       ref={ref}
-
-      className={'flex max-sm:hidden gap-2 min-h-[38px]'}
+      className={cn(
+        "flex max-sm:hidden gap-2 min-w-none w-fit mt-2",
+        isLast
+          ? `min-h-[28px]`
+          : `min-h-[34px] ${isHovered ? 'p-0.5 border border-border rounded-[8px]' : ''}`
+      )}
     >
       {visible && message && (
         <>
@@ -135,7 +139,6 @@ export function MessageActions({
           </Tooltip>
           <Regenerations id={id} />
           <AddMessageTo id={id} />
-
         </>
       )}
     </div>

--- a/src/components/chat-messages/message-actions.tsx
+++ b/src/components/chat-messages/message-actions.tsx
@@ -105,7 +105,7 @@ export function MessageActions({
         "flex max-sm:hidden gap-2 min-w-0 w-fit mt-2",
         isLast
           ? `min-h-[28px]`
-          : `min-h-[34px] ml-0.5 ${isHovered ? 'p-0.5 border border-border rounded-[8px] shadow-md' : ''}`
+          : `min-h-[34px] ml-0.5 absolute -bottom-[34px] ${isHovered ? 'p-0.5 border border-border rounded-[8px] shadow-md' : ''}`
       )}
     >
       {visible && message && (

--- a/src/components/chat-messages/message-actions.tsx
+++ b/src/components/chat-messages/message-actions.tsx
@@ -105,7 +105,7 @@ export function MessageActions({
         "flex max-sm:hidden gap-2 min-w-0 w-fit mt-2",
         isLast
           ? `min-h-[28px]`
-          : `min-h-[34px] ml-0.5 ${isHovered ? 'p-0.5 border border-border rounded-[8px]' : ''}`
+          : `min-h-[34px] ml-0.5 ${isHovered ? 'p-0.5 border border-border rounded-[8px] shadow-md' : ''}`
       )}
     >
       {visible && message && (

--- a/src/components/chat-messages/message-sources.tsx
+++ b/src/components/chat-messages/message-sources.tsx
@@ -42,7 +42,7 @@ function MessageSources({
   }, [getView, sources, t]);
 
   return (
-    <div className={'flex px-10 flex-col pb-2 max-sm:hidden'}>
+    <div className={'flex flex-col pb-2 max-sm:hidden'}>
       <Button
         onClick={() => setExpanded(!expanded)}
         variant={'link'}

--- a/src/components/chat-messages/message-suggestions.tsx
+++ b/src/components/chat-messages/message-suggestions.tsx
@@ -42,7 +42,7 @@ export function MessageSuggestions({ suggestions }: MessageSuggestionsProps) {
       initial={'hidden'}
       animate="visible"
       variants={MESSAGE_VARIANTS.getSuggestionsVariants()}
-      className={'flex flex-col gap-4 w-full overflow-hidden mr-auto'}
+      className={'flex flex-col gap-4 w-full overflow-hidden mr-auto mt-9'}
     >
       <Label className={'opacity-60'}>{t('suggestion.title')}</Label>
       <div className={'flex gap-2 flex-col items-start w-full overflow-hidden'}>

--- a/src/components/chat-messages/message.tsx
+++ b/src/components/chat-messages/message.tsx
@@ -1,3 +1,4 @@
+import { useChatContext } from '@/chat/context';
 import { AIAnswer } from '@/components/chat-messages/ai-answer';
 import { AssistantMessage } from '@/components/chat-messages/assistant-message';
 import HumanQuestion from '@/components/chat-messages/human-question';
@@ -35,6 +36,24 @@ export const Message = ({
 
   const message = useMemo(() => getMessage(id), [id, getMessage]);
 
+  const { selectionMode } = useChatContext();
+
+  const className = useMemo(() => {
+    if (!message) return '';
+    
+    const classList = [];
+    
+    if (message.author.author_type === AuthorType.Human || selectionMode) {
+      classList.push('mb-9');
+    }
+    
+    if (selected) {
+      classList.push('bg-primary/5');
+    }
+
+    return classList.join(' ');
+  }, [message, selected, selectionMode]);
+
   const renderMessage = useCallback(() => {
     if(!message) {
       return null;
@@ -60,7 +79,6 @@ export const Message = ({
           fetchMember={fetchMember}
           userId={message.author.author_uuid}
           content={message.content}
-
         />;
     }
 
@@ -74,8 +92,8 @@ export const Message = ({
       variants={MESSAGE_VARIANTS.getMessageVariants()}
       onAnimationComplete={() => shouldAnimate && completeAnimation(id)}
       className={cn(
-        'flex rounded-[8px] message flex-col py-2 overflow-hidden',
-        selected ? 'bg-primary/5' : '',
+        'flex rounded-[8px] message flex-col',
+        className,
       )}
     >
       {renderMessage()}

--- a/src/components/chat-messages/message.tsx
+++ b/src/components/chat-messages/message.tsx
@@ -1,4 +1,3 @@
-import { useChatContext } from '@/chat/context';
 import { AIAnswer } from '@/components/chat-messages/ai-answer';
 import { AssistantMessage } from '@/components/chat-messages/assistant-message';
 import HumanQuestion from '@/components/chat-messages/human-question';
@@ -35,8 +34,6 @@ export const Message = ({
   }), [id, messages]);
 
   const message = useMemo(() => getMessage(id), [id, getMessage]);
-
-  const { selectionMode } = useChatContext();
 
   const renderMessage = useCallback(() => {
     if(!message) {
@@ -75,14 +72,7 @@ export const Message = ({
       animate="visible"
       variants={MESSAGE_VARIANTS.getMessageVariants()}
       onAnimationComplete={() => shouldAnimate && completeAnimation(id)}
-      className={cn(
-        'flex rounded-[8px] message flex-col',
-        message &&
-          (message.author.author_type === AuthorType.Human || selectionMode)
-          ? 'mb-9'
-          : '',
-        message && selected ? 'bg-primary/5' : '',
-      )}
+      className={`mb-9 ${message && selected ? 'bg-primary/5' : ''}`}
     >
       {renderMessage()}
     </motion.div>

--- a/src/components/chat-messages/message.tsx
+++ b/src/components/chat-messages/message.tsx
@@ -38,24 +38,6 @@ export const Message = ({
 
   const { selectionMode } = useChatContext();
 
-  const className = useMemo(() => {
-    if (!message) {
-      return '';
-    }
-    
-    const classList = [];
-    
-    if (message.author.author_type === AuthorType.Human || selectionMode) {
-      classList.push('mb-9');
-    }
-    
-    if (selected) {
-      classList.push('bg-primary/5');
-    }
-
-    return classList.join(' ');
-  }, [message, selected, selectionMode]);
-
   const renderMessage = useCallback(() => {
     if(!message) {
       return null;
@@ -95,11 +77,14 @@ export const Message = ({
       onAnimationComplete={() => shouldAnimate && completeAnimation(id)}
       className={cn(
         'flex rounded-[8px] message flex-col',
-        className,
+        message &&
+          (message.author.author_type === AuthorType.Human || selectionMode)
+          ? 'mb-9'
+          : '',
+        message && selected ? 'bg-primary/5' : '',
       )}
     >
       {renderMessage()}
     </motion.div>
   );
 };
-

--- a/src/components/chat-messages/message.tsx
+++ b/src/components/chat-messages/message.tsx
@@ -39,7 +39,9 @@ export const Message = ({
   const { selectionMode } = useChatContext();
 
   const className = useMemo(() => {
-    if (!message) return '';
+    if (!message) {
+      return '';
+    }
     
     const classList = [];
     

--- a/src/components/chat-messages/message.tsx
+++ b/src/components/chat-messages/message.tsx
@@ -2,7 +2,6 @@ import { AIAnswer } from '@/components/chat-messages/ai-answer';
 import { AssistantMessage } from '@/components/chat-messages/assistant-message';
 import HumanQuestion from '@/components/chat-messages/human-question';
 import { MESSAGE_VARIANTS } from '@/lib/animations';
-import { cn } from '@/lib/utils';
 import { useMessageAnimation } from '@/provider/message-animation-provider';
 import { useChatMessagesContext } from '@/provider/messages-provider';
 import { useSelectionModeContext } from '@/provider/selection-mode-provider';

--- a/src/components/chat-messages/message.tsx
+++ b/src/components/chat-messages/message.tsx
@@ -2,6 +2,7 @@ import { AIAnswer } from '@/components/chat-messages/ai-answer';
 import { AssistantMessage } from '@/components/chat-messages/assistant-message';
 import HumanQuestion from '@/components/chat-messages/human-question';
 import { MESSAGE_VARIANTS } from '@/lib/animations';
+import { cn } from '@/lib/utils';
 import { useMessageAnimation } from '@/provider/message-animation-provider';
 import { useChatMessagesContext } from '@/provider/messages-provider';
 import { useSelectionModeContext } from '@/provider/selection-mode-provider';
@@ -71,7 +72,10 @@ export const Message = ({
       animate="visible"
       variants={MESSAGE_VARIANTS.getMessageVariants()}
       onAnimationComplete={() => shouldAnimate && completeAnimation(id)}
-      className={`mb-9 ${message && selected ? 'bg-primary/5' : ''}`}
+      className={cn(
+        'message rounded-[8px] mb-9',
+        selected ? 'bg-primary/5' : '',
+      )}
     >
       {renderMessage()}
     </motion.div>

--- a/src/provider/messages-handler-provider.tsx
+++ b/src/provider/messages-handler-provider.tsx
@@ -277,7 +277,7 @@ function useMessagesHandler() {
       return Promise.reject(e);
 
     }
-  }, [getMessage, setResponseFormatWithId, saveAnswer, startFetchSuggestions, removeAssistantMessage, requestInstance, toast]);
+  }, [getMessage, setResponseFormatWithId, saveAnswer, messageIds, startFetchSuggestions, removeAssistantMessage, requestInstance, toast]);
 
   const cancelAnswerStream = useCallback(() => {
     if(cancelStreamRef.current) {

--- a/src/provider/messages-handler-provider.tsx
+++ b/src/provider/messages-handler-provider.tsx
@@ -231,7 +231,9 @@ function useMessagesHandler() {
           void (async() => {
             await saveAnswer(questionId, message, metadata);
             setAnswerApplying(false);
-            await startFetchSuggestions(questionId);
+            if (answerId && messageIds.indexOf(answerId) === 0) {
+              await startFetchSuggestions(questionId);
+            }
           })();
         } else {
           if(answerId) {


### PR DESCRIPTION
1. Adjust padding between messages
2. Remove x-axis padding in message sources
3. Show suggestions only when not empty

### **Description**
<!---
Provide a clear and concise description of the changes introduced in this pull request for AppFlowy Web. What problem does it solve? What value does it add?
-->

---

### **Checklist**
<!---
Before marking your pull request as ready for review, ensure the following checklist is complete.
-->

#### **General**
- [ ] I've included relevant documentation or comments for the changes introduced.
- [ ] I've tested the changes in multiple environments (e.g., different browsers, operating systems).

#### **Testing**
- [ ] I've added or updated tests to validate the changes introduced for AppFlowy Web.

#### **Feature-Specific**
- [ ] For feature additions, I've added a preview (video, screenshot, or demo) in the "Feature Preview" section.
- [ ] I've verified that this feature integrates seamlessly with existing functionality.

## Summary by Sourcery

Adjust message list layout and spacing, introduce message selection mode with checkboxes, and refine suggestion fetching and conditional rendering

Bug Fixes:
- Fix inconsistent vertical spacing between messages by standardizing bottom margins based on message state and position
- Prevent redundant suggestion fetch by only invoking startFetchSuggestions for the latest answer

Enhancements:
- Add message selection mode with checkboxes and selected-state highlighting
- Refine conditional rendering logic for loading indicators, message content, and suggestions